### PR TITLE
Implemented GitHub Action for PyPi publishing on Release

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,39 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.x'
+        python-version: '3.9'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/dgi/__init__.py
+++ b/dgi/__init__.py
@@ -1,0 +1,2 @@
+""" DGI Package """
+__version__ = "0.1.0"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='tackle-dgi',
-    version='0.0.4',
+    version='0.1.0',
     url="https://github.com/konveyor/tackle-data-gravity-insights",
     author="IBM",
     description="Konveyor Tackle Data Gravity Insights",
@@ -39,7 +39,9 @@ setup(
             "coverage==6.3.2",
             "pylint==2.13",
             "py2neo==2021.2.3",
-            "tox==3.24.5",
+            "flake8==4.0.1",
+            "black==22.3.0",
+            "tox==3.24.5"
         ],
     },
     entry_points={


### PR DESCRIPTION
Made the following changes:
- Added `python-publish.yaml` GitHub Action to publish to PyPi for each release
- Added `PYPI_API_TOKEN` secret to repo for GitHub action
- Bumped the minor version to `0.1.0` since we made breaking cli changes to `0.0.4`
- Added a `__version__` variable to `__init__.py` as per Python convention 

Linked to #38